### PR TITLE
Improve snippet for TS Functional component

### DIFF
--- a/packages/vscode/snippets/react-typescript.json
+++ b/packages/vscode/snippets/react-typescript.json
@@ -22,15 +22,15 @@
   "rfct": {
     "prefix": "rfct",
     "body": [
-      "import React from \"react\";",
+      "import React from 'react'",
       "",
-      "interface I${1:${TM_FILENAME_BASE}}Props {}",
-      "",
-      "function ${1:${TM_FILENAME_BASE}}({}: I${1:${TM_FILENAME_BASE}}Props): JSX.Element {",
-      "  return <div></div>;",
+      "interface ${TM_FILENAME_BASE}Props {",
+      "$1",
       "}",
       "",
-      "export default ${1:${TM_FILENAME_BASE}};"
+      "export const $TM_FILENAME_BASE: React.FC<${TM_FILENAME_BASE}Props> = ({$2}) => {",
+      "\t\treturn ($3);",
+      "}"
     ],
     "description": "Typescript: React functional component"
   },

--- a/packages/vscode/snippets/react-typescript.json
+++ b/packages/vscode/snippets/react-typescript.json
@@ -24,9 +24,7 @@
     "body": [
       "import React from 'react'",
       "",
-      "interface ${TM_FILENAME_BASE}Props {",
-      "$1",
-      "}",
+      "interface ${TM_FILENAME_BASE}Props {}",
       "",
       "export const $TM_FILENAME_BASE: React.FC<${TM_FILENAME_BASE}Props> = ({$2}) => {",
       "\t\treturn ($3);",

--- a/packages/vscode/snippets/react-typescript.json
+++ b/packages/vscode/snippets/react-typescript.json
@@ -22,11 +22,11 @@
   "rfct": {
     "prefix": "rfct",
     "body": [
-      "import React from 'react'",
+      "import type { FC } from 'react'",
       "",
       "interface ${TM_FILENAME_BASE}Props {}",
       "",
-      "export const $TM_FILENAME_BASE: React.FC<${TM_FILENAME_BASE}Props> = ({$2}) => {",
+      "export const $TM_FILENAME_BASE: FC<${TM_FILENAME_BASE}Props> = ({$2}) => {",
       "\t\treturn ($3);",
       "}"
     ],


### PR DESCRIPTION

## Fixes Issue
Improves the snippet IMO

Before:
```tsx
import React from "react";

interface IExampleProps {}

function Example({}: IExampleProps): JSX.Element {
  return <div></div>;
}

export default Example;
```

After:
```tsx
import React from 'react'

interface ExampleProps {}

export const Example: React.FC<ExampleProps> = ({}) => {
    return ();
}
```

