### PR TITLE
fix: capitalize first letter on the use state snippet

### DIFF
--- a/src/extension/snippets/react-typescript.json
+++ b/src/extension/snippets/react-typescript.json
@@ -45,7 +45,7 @@
   },
   "rust": {
     "prefix": "rust",
-    "body": ["const [${1}, set${1}] = useState(${2});"],
+    "body": ["const [${1}, set${1/(.*)/${1:/capitalize}/}] = useState(${2});"],
     "description": "TypeScript: useState hook"
   },
   "ruct": {


### PR DESCRIPTION
## Changes proposed

I capitalized the first letter on the use state snippet, just pressing a tab after write

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

